### PR TITLE
对pcntl_waitpid返回值进行判断,防止僵尸进程

### DIFF
--- a/8. php多进程初探---进程间通信二三事.md
+++ b/8. php多进程初探---进程间通信二三事.md
@@ -130,7 +130,9 @@ for( $i = 1; $i <= 2; $i++ ){
 }
 while( !empty( $child_pid ) ){
   foreach( $child_pid as $pid_key => $pid_item ){
-    pcntl_waitpid( $pid_item, $status, WNOHANG );
+        $wait_result=pcntl_waitpid( $pid_item, $status, WNOHANG );
+	//必须判断子进程回收的状态,如果不加判断,第一次两个子进程返回都是0,直接unset后会无法进入while,导致僵尸进程
+        if($wait_result == -1 || $wait_result > 0)
 	unset( $child_pid[ $pid_key ] );
   }
 }


### PR DESCRIPTION
今天上午理解错了,现在找到变成僵尸进程原因